### PR TITLE
Ported stackableEmptyShulkerBoxes to carpetmod for 1.13.1

### DIFF
--- a/patches/net/minecraft/block/BlockShulkerBox.java.patch
+++ b/patches/net/minecraft/block/BlockShulkerBox.java.patch
@@ -1,0 +1,27 @@
+--- a/net/minecraft/block/BlockShulkerBox.java
++++ b/net/minecraft/block/BlockShulkerBox.java
+@@ -2,6 +2,8 @@
+ 
+ import java.util.List;
+ import javax.annotation.Nullable;
++
++import carpet.CarpetSettings;
+ import net.minecraft.block.material.EnumPushReaction;
+ import net.minecraft.block.state.BlockFaceShape;
+ import net.minecraft.block.state.IBlockState;
+@@ -177,7 +179,14 @@
+                 if (!tileentityshulkerbox.isCleared() && tileentityshulkerbox.shouldDrop())
+                 {
+                     ItemStack itemstack = new ItemStack(this);
+-                    itemstack.getOrCreateTag().setTag("BlockEntityTag", ((TileEntityShulkerBox)tileentity).saveToNbt(new NBTTagCompound()));
++                    // [CM] Added nbttagcompound and if
++                    NBTTagCompound nbttagcompound = new NBTTagCompound();
++                    itemstack.getOrCreateTag().setTag("BlockEntityTag", ((TileEntityShulkerBox)tileentity).saveToNbt(nbttagcompound));
++                    if(!CarpetSettings.getBool("stackableEmptyShulkerBoxes") || !nbttagcompound.isEmpty())
++                    {
++                        itemstack.setTag(new NBTTagCompound());
++                    }
++                    // [CM] end
+ 
+                     if (tileentityshulkerbox.hasCustomName())
+                     {

--- a/patches/net/minecraft/block/BlockShulkerBox.java.patch
+++ b/patches/net/minecraft/block/BlockShulkerBox.java.patch
@@ -9,17 +9,18 @@
  import net.minecraft.block.material.EnumPushReaction;
  import net.minecraft.block.state.BlockFaceShape;
  import net.minecraft.block.state.IBlockState;
-@@ -177,7 +179,14 @@
+@@ -177,7 +179,15 @@
                  if (!tileentityshulkerbox.isCleared() && tileentityshulkerbox.shouldDrop())
                  {
                      ItemStack itemstack = new ItemStack(this);
 -                    itemstack.getOrCreateTag().setTag("BlockEntityTag", ((TileEntityShulkerBox)tileentity).saveToNbt(new NBTTagCompound()));
 +                    // [CM] Added nbttagcompound and if
 +                    NBTTagCompound nbttagcompound = new NBTTagCompound();
-+                    itemstack.getOrCreateTag().setTag("BlockEntityTag", ((TileEntityShulkerBox)tileentity).saveToNbt(nbttagcompound));
-+                    if(!CarpetSettings.getBool("stackableEmptyShulkerBoxes") || !nbttagcompound.isEmpty())
++                    NBTTagCompound nbttagcompound1 = new NBTTagCompound();
++                    nbttagcompound.setTag("BlockEntityTag", ((TileEntityShulkerBox)tileentity).saveToNbt(nbttagcompound1));
++                    if(!CarpetSettings.getBool("stackableEmptyShulkerBoxes") || nbttagcompound1.size() > 0)
 +                    {
-+                        itemstack.setTag(new NBTTagCompound());
++                        itemstack.setTag(nbttagcompound);
 +                    }
 +                    // [CM] end
  

--- a/patches/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/net/minecraft/entity/item/EntityItem.java.patch
@@ -12,3 +12,26 @@
      public EntityItem(World worldIn)
      {
          super(EntityType.ITEM, worldIn);
+@@ -229,8 +234,22 @@
+                     }
+                     else if (itemstack1.getCount() + itemstack.getCount() > itemstack1.getMaxStackSize())
+                     {
++                        // Add check for stacking shoulkers without NBT on the ground CARPET-XCOM
++                        if (itemstack1.isGroundStackable() && itemstack.isGroundStackable())
++                        {
++                            itemstack1.grow(itemstack.getCount());
++                            other.pickupDelay = Math.max(other.pickupDelay, this.pickupDelay);
++                            other.age = Math.min(other.age, this.age);
++                            other.setItem(itemstack1);
++                            this.remove();
++                            return true;
++                        }
+                         return false;
+                     }
++                    else if (!itemstack1.isStackable() && !itemstack.isStackable())
++                    {
++                        return false;
++                    }
+                     else
+                     {
+                         itemstack1.grow(itemstack.getCount());

--- a/patches/net/minecraft/item/Item.java.patch
+++ b/patches/net/minecraft/item/Item.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/item/Item.java
++++ b/net/minecraft/item/Item.java
+@@ -1210,6 +1210,11 @@
+         return tagIn.contains(this);
+     }
+ 
++    /*
++     * Fix for stack changes when doing NBT checks on shulkers. CARPET-XCOM
++     */
++    public boolean itemGroundStacking(boolean hasTagCompound) { return false; }
++
+     public static class Properties
+         {
+             private int maxStackSize = 64;

--- a/patches/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/net/minecraft/item/ItemBlock.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/item/ItemBlock.java
++++ b/net/minecraft/item/ItemBlock.java
+@@ -3,8 +3,11 @@
+ import java.util.List;
+ import java.util.Map;
+ import javax.annotation.Nullable;
++
++import carpet.CarpetSettings;
+ import net.minecraft.advancements.CriteriaTriggers;
+ import net.minecraft.block.Block;
++import net.minecraft.block.BlockShulkerBox;
+ import net.minecraft.block.SoundType;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.client.util.ITooltipFlag;
+@@ -178,4 +181,14 @@
+     {
+         blockToItemMap.put(this.getBlock(), itemIn);
+     }
++
++    /*
++     * Stack empty shulkers on the ground CARPET-XCOM
++     * Moved and adjusted by Salandora, because ItemShulkerBox got removed
++     */
++    @Override
++    public boolean itemGroundStacking(boolean hasTag)
++    {
++        return getBlock() instanceof BlockShulkerBox && !hasTag && CarpetSettings.getBool("stackableEmptyShulkerBoxes");
++    }
+ }

--- a/patches/net/minecraft/item/ItemStack.java.patch
+++ b/patches/net/minecraft/item/ItemStack.java.patch
@@ -15,15 +15,13 @@
  import net.minecraft.block.state.BlockWorldState;
  import net.minecraft.block.state.IBlockState;
  import net.minecraft.client.util.ITooltipFlag;
-@@ -224,6 +226,11 @@
- 
-     public int getMaxStackSize()
+@@ -1157,4 +1159,9 @@
      {
-+        if (this.getItem() instanceof ItemBlock && ((ItemBlock) this.getItem()).getBlock() instanceof BlockShulkerBox && CarpetSettings.getBool("stackableEmptyShulkerBoxes"))
-+        {
-+            return hasTag() ? 1 : 64;
-+        }
-+
-         return this.getItem().getMaxStackSize();
+         this.grow(-count);
      }
- 
++
++    // Check for ground stacking CARPET-XCOM
++    public boolean isGroundStackable() {
++        return this.getItem().itemGroundStacking(hasTag());
++    }
+ }

--- a/patches/net/minecraft/item/ItemStack.java.patch
+++ b/patches/net/minecraft/item/ItemStack.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/item/ItemStack.java
++++ b/net/minecraft/item/ItemStack.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.item;
+ 
++import carpet.CarpetSettings;
+ import com.google.common.collect.HashMultimap;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Multimap;
+@@ -19,6 +20,7 @@
+ import javax.annotation.Nullable;
+ import net.minecraft.advancements.CriteriaTriggers;
+ import net.minecraft.block.Block;
++import net.minecraft.block.BlockShulkerBox;
+ import net.minecraft.block.state.BlockWorldState;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.client.util.ITooltipFlag;
+@@ -224,6 +226,11 @@
+ 
+     public int getMaxStackSize()
+     {
++        if (this.getItem() instanceof ItemBlock && ((ItemBlock) this.getItem()).getBlock() instanceof BlockShulkerBox && CarpetSettings.getBool("stackableEmptyShulkerBoxes"))
++        {
++            return hasTag() ? 1 : 64;
++        }
++
+         return this.getItem().getMaxStackSize();
+     }
+ 

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -120,7 +120,7 @@ public class CarpetSettings
   //                              .extraInfo("Can cause slight differences in mobs behaviour"),
   ////rule("xpNoCooldown",          "creative", "Players absorb XP instantly, without delay"),
   //!rule("combineXPOrbs",         "creative", "XP orbs combine with other into bigger orbs"),
-  rule("stackableEmptyShulkerBoxes", "survival", "Empty shulker boxes can stack to 64"),
+  rule("stackableEmptyShulkerBoxes", "survival", "Empty shulker boxes can stack to 64  when dropped on the ground"),
   //                              .extraInfo("To move them around between inventories, use shift click to move entire stacks"),
   //!rule("rideableGhasts",        "survival feature", "Named ghasts won't attack players and allow to be ridden and controlled")
   //                              .extraInfo("Hold a ghast tear to bring a tamed ghast close to you",

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -120,7 +120,7 @@ public class CarpetSettings
   //                              .extraInfo("Can cause slight differences in mobs behaviour"),
   ////rule("xpNoCooldown",          "creative", "Players absorb XP instantly, without delay"),
   //!rule("combineXPOrbs",         "creative", "XP orbs combine with other into bigger orbs"),
-  //!rule("stackableEmptyShulkerBoxes", "survival", "Empty shulker boxes can stack to 64 when dropped on the ground")
+  rule("stackableEmptyShulkerBoxes", "survival", "Empty shulker boxes can stack to 64"),
   //                              .extraInfo("To move them around between inventories, use shift click to move entire stacks"),
   //!rule("rideableGhasts",        "survival feature", "Named ghasts won't attack players and allow to be ridden and controlled")
   //                              .extraInfo("Hold a ghast tear to bring a tamed ghast close to you",


### PR DESCRIPTION
This is a slightly different version of the stackableEmptyShulkerBoxes, it is possible to stack them on the ground and in the inventory.
