### PR TITLE
Added rule to use main rotation yaw instead of head rotation yaw

### DIFF
--- a/patches/net/minecraft/entity/Entity.java.patch
+++ b/patches/net/minecraft/entity/Entity.java.patch
@@ -38,7 +38,21 @@
      {
          this.rotationYaw = yaw % 360.0F;
          this.rotationPitch = pitch % 360.0F;
-@@ -1859,7 +1868,7 @@
+@@ -1566,6 +1575,13 @@
+         return partialTicks == 1.0F ? this.rotationYaw : this.prevRotationYaw + (this.rotationYaw - this.prevRotationYaw) * partialTicks;
+     }
+ 
++    // [CM] start useMainYaw fix
++    public float getMainYaw(float partialTicks)
++    {
++        return partialTicks == 1.0F ? this.rotationYaw : this.prevRotationYaw + (this.rotationYaw - this.prevRotationYaw) * partialTicks;
++    }
++    // [CM] end
++
+     protected final Vec3d getVectorForRotation(float pitch, float yaw)
+     {
+         float f = pitch * ((float)Math.PI / 180F);
+@@ -1859,7 +1875,7 @@
      }
  
      @Nullable
@@ -47,7 +61,7 @@
      {
          EntityType<?> entitytype = this.getType();
          ResourceLocation resourcelocation = EntityType.getId(entitytype);
-@@ -2821,6 +2830,10 @@
+@@ -2821,6 +2837,10 @@
  
      public EnumFacing getHorizontalFacing()
      {

--- a/patches/net/minecraft/util/EnumFacing.java.patch
+++ b/patches/net/minecraft/util/EnumFacing.java.patch
@@ -15,7 +15,7 @@
 -        float f1 = -entityIn.getYaw(1.0F) * ((float)Math.PI / 180F);
 +        // [CM] start useMainYaw fix
 +        float f1;
-+        if (!CarpetSettings.getBool("useMainYaw"))
++        if (!CarpetSettings.getBool("placementRotationFix"))
 +        {
 +            f1 = -entityIn.getYaw(1.0F) * ((float)Math.PI / 180F);
 +        }

--- a/patches/net/minecraft/util/EnumFacing.java.patch
+++ b/patches/net/minecraft/util/EnumFacing.java.patch
@@ -1,13 +1,33 @@
 --- a/net/minecraft/util/EnumFacing.java
 +++ b/net/minecraft/util/EnumFacing.java
-@@ -1,5 +1,6 @@
+@@ -1,5 +1,7 @@
  package net.minecraft.util;
  
++import carpet.CarpetSettings;
 +import carpet.helpers.BlockRotator;
  import com.google.common.collect.Iterators;
  import java.util.Arrays;
  import java.util.Comparator;
-@@ -76,6 +77,11 @@
+@@ -63,7 +65,17 @@
+     public static EnumFacing[] getFacingDirections(Entity entityIn)
+     {
+         float f = entityIn.getPitch(1.0F) * ((float)Math.PI / 180F);
+-        float f1 = -entityIn.getYaw(1.0F) * ((float)Math.PI / 180F);
++        // [CM] start useMainYaw fix
++        float f1;
++        if (!CarpetSettings.getBool("useMainYaw"))
++        {
++            f1 = -entityIn.getYaw(1.0F) * ((float)Math.PI / 180F);
++        }
++        else
++        {
++            f1 = -entityIn.getMainYaw(1.0F) * ((float)Math.PI / 180F);
++        }
++        // [CM] end
+         float f2 = MathHelper.sin(f);
+         float f3 = MathHelper.cos(f);
+         float f4 = MathHelper.sin(f1);
+@@ -76,6 +88,11 @@
          float f8 = flag2 ? f5 : -f5;
          float f9 = f6 * f3;
          float f10 = f8 * f3;

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -283,7 +283,7 @@ public class CarpetSettings
   rule("kelpGenerationGrowLimit", "feature", "limits growth limit of newly naturally generated kelp to this amount of blocks")
                                   .choices("25", "0 2 25").setNotStrict(),
   rule("renewableCoral",          "feature", "Alternative cashing strategy for nether portals"),
-
+  rule("useMainYaw",              "fix", "Use default yaw for facing direction"),
         };
         for (CarpetSettingEntry rule: RuleList)
         {

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -283,7 +283,7 @@ public class CarpetSettings
   rule("kelpGenerationGrowLimit", "feature", "limits growth limit of newly naturally generated kelp to this amount of blocks")
                                   .choices("25", "0 2 25").setNotStrict(),
   rule("renewableCoral",          "feature", "Alternative cashing strategy for nether portals"),
-  rule("useMainYaw",              "fix", "Use default yaw for facing direction"),
+  rule("placementRotationFix",              "fix", "fixes block placement rotation issue when player rotates quickly while placing blocks"),
         };
         for (CarpetSettingEntry rule: RuleList)
         {


### PR DESCRIPTION
Fixes a placement bug, where fast head moves lead to e.g. downwards facing pistons. 
Also helps to fix tweakeroo's flexible block placement in 1.13.2.

As an explaination: the getYaw function gets overriden inside the EntityLivingBase class this is why there is a new getMainYaw function with exactly the same content as the getYaw function.

Here is a video from @maruohon show casing the problem: https://www.youtube.com/watch?v=3AnDuy-aj5Q