### PR TITLE
Reintroduced the "dragon egg bedrock remove" bug

### DIFF
--- a/patches/net/minecraft/block/BlockFalling.java.patch
+++ b/patches/net/minecraft/block/BlockFalling.java.patch
@@ -1,0 +1,23 @@
+--- a/net/minecraft/block/BlockFalling.java
++++ b/net/minecraft/block/BlockFalling.java
+@@ -1,6 +1,8 @@
+ package net.minecraft.block;
+ 
+ import java.util.Random;
++
++import carpet.CarpetSettings;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.entity.item.EntityFallingBlock;
+@@ -74,7 +76,10 @@
+ 
+                 if (blockpos.getY() > 0)
+                 {
+-                    worldIn.setBlockState(blockpos.up(), this.getDefaultState());
++                    // [CM] reintroduce dragon egg bedrock breaking
++                    boolean dragonEggHandling = (CarpetSettings.getBool("dragonEggBedrockRemoval") && this instanceof BlockDragonEgg);
++                    worldIn.setBlockState((!dragonEggHandling ? blockpos.up() : blockpos), this.getDefaultState());
++                    // [CM] end
+                 }
+             }
+         }

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -283,7 +283,7 @@ public class CarpetSettings
   rule("kelpGenerationGrowLimit", "feature", "limits growth limit of newly naturally generated kelp to this amount of blocks")
                                   .choices("25", "0 2 25").setNotStrict(),
   rule("renewableCoral",          "feature", "Alternative cashing strategy for nether portals"),
-
+  rule("dragonEggBedrockRemoval", "experimental", "Reintroduce Dragon Egg Bedrock breaking"),
         };
         for (CarpetSettingEntry rule: RuleList)
         {


### PR DESCRIPTION
Here is a litte reintroduction of the dragon egg bedrock remove bug.
I liked that bug and wanted it back in 1.13.

Maybe you're interested too.

Explanation:
As the BlockDragonEgg is now derived from BlockFalling I modified the code of this class to check if it is a DragonEgg and is the CarpetRule enabled.