### PR TITLE
Ported carpet functionality to 1.13.1

### DIFF
--- a/patches/net/minecraft/block/BlockCarpet.java.patch
+++ b/patches/net/minecraft/block/BlockCarpet.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/block/BlockCarpet.java
++++ b/net/minecraft/block/BlockCarpet.java
+@@ -1,8 +1,10 @@
+ package net.minecraft.block;
+ 
++import carpet.utils.WoolTool;
+ import net.minecraft.block.state.BlockFaceShape;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.init.Blocks;
++import net.minecraft.item.BlockItemUseContext;
+ import net.minecraft.item.EnumDyeColor;
+ import net.minecraft.util.EnumFacing;
+ import net.minecraft.util.math.BlockPos;
+@@ -51,4 +53,14 @@
+     {
+         return face == EnumFacing.DOWN ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
+     }
++
++    public IBlockState getStateForPlacement(BlockItemUseContext context)
++    {
++        IBlockState state = super.getStateForPlacement(context);
++        if (context.getPlayer() != null)
++        {
++            WoolTool.carpetPlacedAction(this.color, context.getPlayer(), context.getPos(), context.getWorld());
++        }
++        return state;
++    }
+ }

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -203,7 +203,7 @@ public class CarpetSettings
   rule("commandPlayer",         "commands", "Enables /player command to control/spawn players").isACommand(),
   ////rule("commandRNG",            "commands", "Enables /rng command to manipulate and query rng").defaultTrue(),
   ////rule("newLight",              "optimizations", "Uses alternative lighting engine by PhiPros. AKA NewLight mod"),
-  //!rule("carpets",               "survival", "Placing carpets may issue carpet commands for non-op players"),
+  rule("carpets",               "survival", "Placing carpets may issue carpet commands for non-op players"),
   rule("missingTools",          "survival", "Pistons, Glass and Sponge can be broken faster with their appropriate tools"),
   rule("mobSpawningAlgorithm","experimental","Using version appropriate spawning rules: ")
                                 .extraInfo(" - 1.8 : fixed 4 mobs per pack for all mobs, 'subchunk' rule",

--- a/src/main/java/carpet/commands/DistanceCommand.java
+++ b/src/main/java/carpet/commands/DistanceCommand.java
@@ -41,17 +41,4 @@ public class DistanceCommand
                                 executes( (c) -> DistanceCalculator.setEnd(c.getSource(), Vec3Argument.getVec3(c, "to")))));
         dispatcher.register(command);
     }
-    public static int setStart(CommandSource source, Vec3d pos)
-    {
-        return 1;
-    }
-    public static int setEnd(CommandSource source, Vec3d pos)
-    {
-        return 1;
-    }
-    public static int distance(CommandSource source, Vec3d pos, Vec3d pos2)
-    {
-        Messenger.send(source, DistanceCalculator.findDistanceBetweenTwoPoints(pos, pos2));
-        return 1;
-    }
 }

--- a/src/main/java/carpet/utils/DistanceCalculator.java
+++ b/src/main/java/carpet/utils/DistanceCalculator.java
@@ -13,6 +13,11 @@ public class DistanceCalculator
 {
     public static final HashMap<String, Vec3d> START_POINT_STORAGE = new HashMap<>();
 
+    public static boolean hasStartingPoint(CommandSource source)
+    {
+        return START_POINT_STORAGE.containsKey(source.getName());
+    }
+
     public static List<ITextComponent> findDistanceBetweenTwoPoints(Vec3d pos1, Vec3d pos2)
     {
         double dx = MathHelper.abs((float)pos1.x-(float)pos2.x);
@@ -46,7 +51,7 @@ public class DistanceCalculator
 
     public static int setEnd(CommandSource source, Vec3d pos)
     {
-        if ( !(START_POINT_STORAGE.containsKey(source.getName()) ) )
+        if ( !hasStartingPoint(source) )
         {
             START_POINT_STORAGE.put(source.getName(), pos);
             Messenger.m(source,"gi There was no initial point for "+source.getName());

--- a/src/main/java/carpet/utils/EntityInfo.java
+++ b/src/main/java/carpet/utils/EntityInfo.java
@@ -344,7 +344,7 @@ public class EntityInfo
     {
         try
         {
-            player.getServer().getCommandManager().handleCommand (player.getCommandSource(), "info entity @e[r=5,c=5,type=!player]"); // TODO fix command call
+            player.getServer().getCommandManager().handleCommand (player.getCommandSource(), "info entity @e[type=!minecraft:player,distance=..5,limit=5]");
         }
         catch (Throwable ignored)
         {

--- a/src/main/java/carpet/utils/WoolTool.java
+++ b/src/main/java/carpet/utils/WoolTool.java
@@ -1,13 +1,21 @@
 package carpet.utils;
 
+import carpet.CarpetSettings;
+import carpet.helpers.HopperCounter;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialColor;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.command.CommandSource;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.World;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 public class WoolTool
 {
@@ -19,7 +27,7 @@ public class WoolTool
             Material2Dye.put(color.getMapColor(),color);
         }
     }
-    /*
+
     public static void carpetPlacedAction(EnumDyeColor color, EntityPlayer placer, BlockPos pos, World worldIn)
     {
 		if (!CarpetSettings.getBool("carpets"))
@@ -40,15 +48,21 @@ public class WoolTool
             case BROWN:
                 if (CarpetSettings.getBool("commandDistance"))
                 {
-                    DistanceCalculator.report_distance(placer, pos);
+                    CommandSource source = placer.getCommandSource();
+                    if (!DistanceCalculator.hasStartingPoint(source) || placer.isSneaking()) {
+                        DistanceCalculator.setStart(source, new Vec3d(pos));
+                    }
+                    else {
+                        DistanceCalculator.setEnd(source, new Vec3d(pos));
+                    }
                 }
                 break;
             case GRAY:
-                if (CarpetSettings.getBool("commandBlockInfo"))
+                if (CarpetSettings.getBool("commandInfo"))
                     Messenger.send(placer, BlockInfo.blockInfo(pos.down(), worldIn));
                 break;
             case YELLOW:
-                if (CarpetSettings.getBool("commandEntityInfo"))
+                if (CarpetSettings.getBool("commandInfo"))
                     EntityInfo.issue_entity_info(placer);
                 break;
 			case GREEN:
@@ -56,7 +70,7 @@ public class WoolTool
                 {
                     EnumDyeColor under = getWoolColorAtPosition(worldIn, pos.down());
                     if (under == null) return;
-                    Messenger.send(placer, HopperCounter.query_hopper_stats_for_color(worldIn.getMinecraftServer(), under.toString(), false, false));
+                    Messenger.send(placer, HopperCounter.query_hopper_stats_for_color(worldIn.getServer(), under.toString(), false, false));
                 }
 				break;
 			case RED:
@@ -64,12 +78,14 @@ public class WoolTool
                 {
                     EnumDyeColor under = getWoolColorAtPosition(worldIn, pos.down());
                     if (under == null) return;
-                    HopperCounter.reset_hopper_counter(worldIn, under.toString());
-                    Messenger.s(placer, String.format("%s counter reset",under.toString() ));
+                    HopperCounter.reset_hopper_counter(placer.getServer(), under.toString());
+                    List<ITextComponent> res = new ArrayList<>();
+                    res.add(Messenger.s(String.format("%s counter reset",under.toString())));
+                    Messenger.send(placer, res);
                 }
 			    break;
         }
-    }*/
+    }
 
     public static EnumDyeColor getWoolColorAtPosition(World worldIn, BlockPos pos)
     {


### PR DESCRIPTION
I ported the carpet functionality to 1.13.1.

Important notice:
Because of the new distance command and the changes in the DistanceCalculator I changed the functionality of the brown carpet slightly.

The brown carpet will now set the starting point if no starting point was set previously OR the player is sneaking.
If there was a starting point set, e.g. by a carpet OR a command, it will then set the end point and report back. It will not automatically clear the starting point.
This way it is easily possible to set the starting point once and get the distance to this point from different locations. 