### PR TITLE
Fixed fillUpdates in combinition with setBlock command

### DIFF
--- a/patches/net/minecraft/command/impl/SetBlockCommand.java.patch
+++ b/patches/net/minecraft/command/impl/SetBlockCommand.java.patch
@@ -12,7 +12,7 @@
              }
  
 -            if (flag && !p_198683_2_.place(worldserver, p_198683_1_, 2))
-+            if (flag && !p_198683_2_.place(worldserver, p_198683_1_, 2 | (CarpetSettings.getBool("fillUpdates")?0:128))) // [CM]
++            if (flag && !p_198683_2_.place(worldserver, p_198683_1_, 2 | (CarpetSettings.getBool("fillUpdates")?0:1024))) // [CM]
              {
                  throw field_198689_a.create();
              }


### PR DESCRIPTION
This is a fix for the setBlock command still updating with fillUpdates set to false.

Inside the setBlock command was a flag ored with 128 instead of 1024
Probably an oversight while porting from 1.12.