### PR TITLE
Add a .gitattributes file for line endings on installer scripts. Fixes #110

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.cmd text eol=crlf
+*.sh text eol=lf


### PR DESCRIPTION
After merging this pull request, you also have to run the following git commands locally to make sure you have lf line endings rather than crlf:
```
$ git pull
$ git rm --cached -r .
$ git reset --hard
```