### PR TITLE
Fix for dispensers using 2 shulker boxes

### DIFF
--- a/patches/net/minecraft/init/Bootstrap.java.patch
+++ b/patches/net/minecraft/init/Bootstrap.java.patch
@@ -38,3 +38,12 @@
          for (EnumDyeColor enumdyecolor : EnumDyeColor.values())
          {
              BlockDispenser.registerDispenseBehavior(BlockShulkerBox.getBlockByColor(enumdyecolor).asItem(), new Bootstrap.BehaviorDispenseShulkerBox());
+@@ -642,7 +666,7 @@
+                     EnumFacing enumfacing1 = source.getWorld().isAirBlock(blockpos.down()) ? enumfacing : EnumFacing.UP;
+                     this.successful = ((ItemBlock)item).tryPlace(new Bootstrap.DispensePlaceContext(source.getWorld(), blockpos, enumfacing, stack, enumfacing1)) == EnumActionResult.SUCCESS;
+ 
+-                    if (this.successful)
++                    if (this.successful && !CarpetSettings.b_stackableShulkerBoxes)
+                     {
+                         stack.shrink(1);
+                     }


### PR DESCRIPTION
Just noticed a bug where a dispenser is dispensing 2 shulker boxes if they are stacked together (e.g. by enabling the stackable shulkerbox rule).

This is because in ItemBlock.tryPlace the stack gets shrinked and in BehaviorDispenseShulkerBox it get shrinked again. No big deal for vanilla behaviour, but a problem with carpemods stackable shulker boxes.

I therefore decided to disable the shrinking in the BehaviorDispenseShulkerBox class while the carpet rule is enabled. (This way we can switch back to vanilla behaviour)